### PR TITLE
fix test when not run under a tty

### DIFF
--- a/gspt_test.go
+++ b/gspt_test.go
@@ -36,7 +36,7 @@ func TestSetProcTitle(t *testing.T) {
 
   SetProcTitle(title)
 
-  out, err := exec.Command("/bin/ps", "a").Output()
+  out, err := exec.Command("/bin/ps", "ax").Output()
   if err != nil {
     // No ps available on this platform.
     t.SkipNow()


### PR DESCRIPTION
The BSD syntax "ps a" only prints processes with a tty, which for example isn't the case on the Ubuntu builders, causing the test fo fail:

https://launchpadlibrarian.net/257937819/buildlog_ubuntu-yakkety-amd64.golang-github-erikdubbelboer-gspt_0.0~git20151120.0.bbaae60-1_BUILDING.txt.gz

(this can be reproduced locally by running "ssh localhost GOPATH=<whatever> go test github.com/ErikDubbelboer/gspt"). Fix this by running "ps ax" instead.