### PR TITLE
Fix package name

### DIFF
--- a/example/example.go
+++ b/example/example.go
@@ -9,7 +9,7 @@ import (
   "os"
   "os/exec"
 
-  "github.com/ErikDubbelboer/gspt"
+  "github.com/erikdubbelboer/gspt"
 )
 
 func main() {


### PR DESCRIPTION
'ErikDubbelboer' != 'erikdubbelboer'

Specifically, some dependency management tools will throw an error if the import statement does not match the VCS url and do the comparison case sensitively.