### PR TITLE
Enabling setproctitle_fast from FreeBSD 12.x

### DIFF
--- a/example/example.go
+++ b/example/example.go
@@ -13,6 +13,7 @@ import (
 
 func main() {
 	fmt.Println("HaveSetProcTitle:", gspt.HaveSetProcTitle)
+	fmt.Println("HaveSetProcTitleFast:", gspt.HaveSetProcTitleFast)
 
 	gspt.SetProcTitle("some title")
 

--- a/gspt.go
+++ b/gspt.go
@@ -22,10 +22,12 @@ const (
 
 var (
 	HaveSetProcTitle int
+	HaveSetProcTitleFast int
 )
 
 func init() {
 	HaveSetProcTitle = int(C.spt_init1())
+	HaveSetProcTitleFast = int(C.spt_fast_init1())
 
 	if HaveSetProcTitle == HaveReplacement {
 		newArgs := make([]string, len(os.Args))
@@ -59,4 +61,11 @@ func SetProcTitle(title string) {
 	defer C.free(unsafe.Pointer(cs))
 
 	C.spt_setproctitle(cs)
+}
+
+func SetProcTitleFast(title string) {
+	cs := C.CString(title)
+	defer C.free(unsafe.Pointer(cs))
+
+	C.spt_setproctitle_fast(cs)
 }

--- a/gspt_test.go
+++ b/gspt_test.go
@@ -41,3 +41,21 @@ func TestSetProcTitle(t *testing.T) {
 		t.FailNow()
 	}
 }
+
+func TestSetProcTitleFast(t *testing.T) {
+	if HaveSetProcTitleFast == HaveNone {
+		t.SkipNow()
+	}
+
+	title := randomMD5()
+
+	SetProcTitleFast(title)
+
+	out, err := exec.Command("/bin/ps", "ax").Output()
+	if err != nil {
+		// No ps available on this platform.
+		t.SkipNow()
+	} else if !strings.Contains(string(out), title) {
+		t.FailNow()
+	}
+}


### PR DESCRIPTION
which is not a replacement of the classic setproctitle
but meant for contexts when calls are constant as
the fast flavor avoids the communication with the kernel.