### PR TITLE
Added Power Support ppc64le

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,11 @@
 language: go
+arch:
+  - amd64
+  - ppc64le
 go:
   - 1.1
   - tip
+jobs:
+ exclude:
+  - arch: ppc64le
+    go: 1.1

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,7 @@ arch:
   - amd64
   - ppc64le
 go:
-  - 1.1
-  - tip
-jobs:
- exclude:
-  - arch: ppc64le
-    go: 1.1
+  - 1.15.x
+  - 1.14.x
+  - 1.13.x
+  - 1.12.x


### PR DESCRIPTION
Added power support for the travis.yml file with ppc64le. This is part of the Ubuntu distribution for ppc64le. This helps us simplify testing later when distributions are re-building and re-releasing.